### PR TITLE
Default board change

### DIFF
--- a/discord.js
+++ b/discord.js
@@ -60,7 +60,7 @@ export const startDiscord = () => {
 
     client.on('messageCreate', data => {
         if (data.channelId === config.DISCORD_CHANNEL_ID && data.author.id !== config.DISCORD_BOT_ID) {
-            sendHuginMessage(data.author.username, (data.content), "Home")
+            sendHuginMessage(data.author.username, (data.content), "Discord")
         }
     })
 }
@@ -96,4 +96,3 @@ export const sendDiscordMessage = (nickname, message, board) => {
     console.log(`Sent Discord message`)
     console.log(`${board} | ${nickname}: ${message}`)
 }
-

--- a/hugin.js
+++ b/hugin.js
@@ -122,7 +122,7 @@ export const sendHuginMessage = async (nickname, message, board, fee=10000, atte
               console.log(`Fee already too high, ignoring subsequent attempts`);
             }
             console.log(`Trying again with fee ${new_fee}.`);
-            sendHuginMessage(nickname, message, fee, attempt + 1);
+            sendHuginMessage(nickname, message, board, fee, attempt + 1);
         }
 
     } catch(err) {


### PR DESCRIPTION
Fixes an issue where new attempts to send messages with too low fee failed because the board name was not included in the function call.

Also sends messages to the "Discord" channel on Hugin instead of "Home" as default.